### PR TITLE
ci: ajusta dependabot, target branch e fluxo de release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,11 @@ updates:
   # Frontend: React / Vite / TS (package.json + pnpm-lock.yaml na raiz)
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     groups:
       # Agrupa minor + patch num PR só pra reduzir ruído
       npm-minor-patch:
@@ -21,10 +22,11 @@ updates:
   # Backend Tauri: dependências Rust (src-tauri/Cargo.toml)
   - package-ecosystem: "cargo"
     directory: "/src-tauri"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     groups:
       cargo-minor-patch:
         update-types:
@@ -36,6 +38,7 @@ updates:
   # Actions usadas nos workflows (.github/workflows)
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
             librsvg2-dev patchelf libssl-dev pkg-config fakeroot rpm
 
       - name: Install frontend dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build and Package Tauri App
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
## O que muda

Ajusta a automação do repo (Dependabot, CI e Release) para o fluxo `dev → main → tag`.

- **dependabot:** limita a 3 PRs por ecossistema, agenda semanal (segunda) e aponta o `target-branch` para `dev`
- **ci:** mantém validação (lint + build + cargo check) em PRs e push na `main`
- **release:** usa lockfile do pnpm para sincronizar com o CI

## Fluxo

`dev` (PRs + Dependabot) → merge em `main` (CI) → tag `v*` (release)