### PR TITLE
docs: adiciona seção de permissões do Docker no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ A modern, native, and blazing-fast desktop application to manage your Docker env
 
 ## 🚀 Getting Started
 
+### ⚠️ Docker Permissions (Required)
+
+This application connects directly to the Docker daemon (via `/var/run/docker.sock`), so **your user must be in the `docker` group** — otherwise the app won't be able to list or manage your containers/images, regardless of how you installed it (`.deb`, `.rpm`, AppImage, or built from source).
+
+If you can't run `docker run hello-world` without `sudo`, set it up first:
+
+```bash
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker
+```
+
+Log out and back in (or restart your VM, if you're using one) for the change to take full effect. Full details in the [official Docker post-install guide](https://docs.docker.com/engine/install/linux-postinstall/).
+
 ### Prerequisites
 
 - Node.js (`v20` or higher recommended)


### PR DESCRIPTION
## O que mudou

Adiciona uma nova seção **"⚠️ Docker Permissions (Required)"** no README,logo no início de "Getting Started", explicando que o usuário precisa estar no grupo `docker` para a aplicação conseguir se conectar aodaemon via `/var/run/docker.sock`.

## Por quê

A aplicação depende de acesso direto ao socket do Docker (via Bollard). Sem estar no grupo `docker`, o usuário consegue instalar e abrir o app normalmente, mas todas as operações de containers/imagens falham silenciosamente ou com erro de permissão — isso vale para qualquer método de instalação (.deb, .rpm, AppImage ou build manual).

## Conteúdo adicionado

- Comandos para criar o grupo `docker` e adicionar o usuário
- Aviso sobre necessidade de logout/restart da VM para efetivar a mudança
- Link para a [documentação oficial do Docker](https://docs.docker.com/engine/install/linux-postinstall/)

## Checklist

- [x] Apenas alteração de documentação, sem mudança de código
- [x] Testado visualmente o Markdown renderizado