### PR TITLE
deps: atualiza recharts para ultima versão v2 suportada

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.12.2",
     "react-router-dom": "^6.26.2",
-    "recharts": "^2.12.7",
+    "recharts": "^2.15.4",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,7 +162,7 @@ importers:
         specifier: ^6.26.2
         version: 6.30.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       recharts:
-        specifier: ^2.12.7
+        specifier: ^2.15.4
         version: 2.15.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       sonner:
         specifier: ^1.5.0


### PR DESCRIPTION
### Resumo
Atualiza a biblioteca Recharts para a ultima versão estável do major v2. Verão v3 introduz breaking change, por isso um bump mais conservador